### PR TITLE
output: explicitly disable mouse and enable cursor on exit

### DIFF
--- a/awrit/tty/output.cc
+++ b/awrit/tty/output.cc
@@ -84,7 +84,14 @@ void Setup() {
 
 void Cleanup() {
   fputs(CLEAR_SCREEN, stdout);
-  SetModes({alternate_screen}, false);
+  // clang-format off
+  SetModes({
+    alternate_screen,
+    mouse_move_tracking,
+    mouse_sgr_pixel_mode
+  }, false);
+  // clang-format on
+  SetModes({text_cursor}, true);
   fputs(RESTORE_PRIVATE_MODE_VALUES RESTORE_CURSOR RESTORE_COLORS, stdout);
   fflush(stdout);
 }


### PR DESCRIPTION
SAVE_PRIVATE_MODE_VALUES and RESTORE_PRIVATE_MODE_VALUES when passed
with no modes are a Kitty extension to XTSAVE and XTRESTORE which
saves/restores *all* private modes. To my knowledge, Kitty is the only
terminal which implements this extension.CLEAR_SCREEN

As a result, when exiting awrit in a terminal which *does not* use this
extensions, the cursor is left hidden and mouse mode is left enabled.
Explicitly disable requested mouse reporting modes and show the cursor.

Reference: https://github.com/ghostty-org/ghostty/discussions/2732
Fixes: #20 
