### PR TITLE
Update run-shim, use `/usr/bin/env bash`

### DIFF
--- a/awrit-native-rs/run-shim
+++ b/awrit-native-rs/run-shim
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Check if any argument is provided
 if [ $# -eq 0 ]; then


### PR DESCRIPTION
NixOS have no `/bin/bash`.

https://github.com/chase/awrit/pull/83